### PR TITLE
feat: add secrets to `bjerk-io`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+stack.json

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@pulumi/gcp": "^4.18.0",
+    "@pulumi/github": "^3.4.0",
     "@pulumi/pulumi": "^2.24.1"
   },
   "license": "Apache-2.0"

--- a/src/components/projects-on-github.ts
+++ b/src/components/projects-on-github.ts
@@ -1,0 +1,95 @@
+import * as pulumi from '@pulumi/pulumi';
+import { billingAccount, pulumiAccessToken } from '../config';
+import * as gcp from '@pulumi/gcp';
+import * as github from '@pulumi/github';
+
+export interface ProjectOnGithubSpec {
+  projectName: pulumi.Input<string>;
+  folderId: pulumi.Input<string>;
+  repository: pulumi.Input<string>;
+  projectAliases?: pulumi.Input<pulumi.URN | pulumi.Alias>[];
+}
+
+export class ProjectOnGithub extends pulumi.ComponentResource {
+  readonly project: gcp.organizations.Project;
+
+  // Google Provider
+  readonly googleProvider: gcp.Provider;
+
+  // Service Account
+  readonly serviceAccount: gcp.serviceaccount.Account;
+  readonly serviceAccountKey: gcp.serviceaccount.Key;
+
+  // Secrets
+  readonly ghPulumiSecret: github.ActionsSecret;
+  readonly ghGCPKeySecret: github.ActionsSecret;
+  readonly ghGCPProjectSecret: github.ActionsSecret;
+
+  constructor(
+    name: string,
+    args: ProjectOnGithubSpec,
+    opts?: pulumi.ComponentResourceOptions,
+  ) {
+    super('bjerk:project', name, args, opts);
+
+    const { projectName, folderId, repository, projectAliases } = args;
+
+    this.project = new gcp.organizations.Project(
+      name,
+      {
+        autoCreateNetwork: true,
+        billingAccount,
+        name: projectName,
+        projectId: projectName,
+        folderId,
+      },
+      { protect: true, parent: this, aliases: projectAliases },
+    );
+
+    this.googleProvider = new gcp.Provider(
+      name,
+      {
+        project: this.project.projectId,
+      },
+      { parent: this },
+    );
+
+    this.ghPulumiSecret = new github.ActionsSecret(
+      `${name}-pulumi`,
+      {
+        secretName: 'PULUMI_ACCESS_TOKEN',
+        plaintextValue: pulumiAccessToken,
+        repository,
+      },
+      { parent: this },
+    );
+
+    this.serviceAccount = new gcp.serviceaccount.Account(
+      name,
+      {
+        accountId: 'deploy',
+      },
+      { provider: this.googleProvider, parent: this },
+    );
+
+    this.serviceAccountKey = new gcp.serviceaccount.Key(
+      name,
+      {
+        serviceAccountId: this.serviceAccount.accountId,
+      },
+      { provider: this.googleProvider, parent: this },
+    );
+
+    this.ghGCPKeySecret = new github.ActionsSecret(`${name}-gcp-key`, {
+      secretName: 'GOOGLE_PROJECT_SA_KEY',
+      plaintextValue: this.serviceAccountKey.privateKey,
+      repository,
+    });
+
+    this.ghGCPProjectSecret = new github.ActionsSecret(`${name}-gcp-project`, {
+      secretName: 'GOOGLE_PROJECT_ID',
+      plaintextValue: this.project.projectId,
+      repository,
+    });
+  }
+}

--- a/src/components/projects-on-github.ts
+++ b/src/components/projects-on-github.ts
@@ -58,7 +58,7 @@ export class ProjectOnGithub extends pulumi.ComponentResource {
       `${name}-pulumi`,
       {
         secretName: 'PULUMI_ACCESS_TOKEN',
-        plaintextValue: pulumiAccessToken,
+        plaintextValue: pulumiAccessToken.apply(t => t || ''),
         repository,
       },
       { parent: this },

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,5 +3,5 @@ import * as pulumi from '@pulumi/pulumi';
 export const config = new pulumi.Config();
 export const billingAccount = config.requireSecret('billingAccount');
 export const organizationNumber = 904377566042;
-export const pulumiAccessToken = pulumi.secret(process.env.PULUMI_ACCESS_TOKEN);
-export const githubToken = pulumi.secret(process.env.GITHUB_TOKEN);
+export const pulumiAccessToken = pulumi.secret<string>(process.env.PULUMI_ACCESS_TOKEN);
+export const githubToken = pulumi.secret<string>(process.env.GITHUB_TOKEN);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
 import * as pulumi from '@pulumi/pulumi';
 
 export const config = new pulumi.Config();
-export const billingAccount = config.getSecret('billingAccount');
+export const billingAccount = config.requireSecret('billingAccount');
 export const organizationNumber = 904377566042;
+export const pulumiAccessToken = pulumi.secret(process.env.PULUMI_ACCESS_TOKEN);
+export const githubToken = pulumi.secret(process.env.GITHUB_TOKEN);

--- a/src/internal/bjerk-io.ts
+++ b/src/internal/bjerk-io.ts
@@ -1,15 +1,11 @@
-import * as gcp from '@pulumi/gcp';
-import { billingAccount } from '../config';
+import { ProjectOnGithub } from '../components/projects-on-github';
 import { folder } from './folder';
 
-export const project = new gcp.organizations.Project(
-  'bjerk-io',
-  {
-    autoCreateNetwork: true,
-    billingAccount,
-    name: 'bjerk-io',
-    projectId: 'bjerk-io',
-    folderId: folder.id,
-  },
-  { protect: true },
-);
+export const setup = new ProjectOnGithub('bjerk-io', {
+  projectName: 'bjerk-io',
+  folderId: folder.id,
+  repository: 'bjerkio/bjerk-io-inra',
+  projectAliases: [
+    'urn:pulumi:prod::bjerk-io-core::gcp:organizations/project:Project::bjerk-io',
+  ],
+});

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -1,0 +1,6 @@
+import * as github from '@pulumi/github';
+import { githubToken } from '../config';
+
+export const provider = new github.Provider('github-provider', {
+  token: githubToken,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -142,6 +142,13 @@
     "@types/express" "^4.16.0"
     read-package-json "^2.0.13"
 
+"@pulumi/github@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/github/-/github-3.4.0.tgz#73a6f7981c94f0410ff5eeb9e2ac710744bb76c5"
+  integrity sha512-uPZg4lVuRbHq8GFHqsINydhfV4vqhQhnVVIRMS5NdDIwvE3MADA8rzGzN4IeiWOeFAoxokE5xUJ83iatdR7crw==
+  dependencies:
+    "@pulumi/pulumi" "^2.15.0"
+
 "@pulumi/pulumi@^2.15.0", "@pulumi/pulumi@^2.24.1":
   version "2.24.1"
   resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-2.24.1.tgz#79ec88c1c4576064b7dd31cccd6ea4bb0e7bed10"


### PR DESCRIPTION
- Adds secrets for `bjerk-io` project (enable sending changes)
- Adds a Pulumi component to handle Google Cloud Platforms managed through Github.
